### PR TITLE
Add conditional disable attribute

### DIFF
--- a/Assets/EditorCools/ConditionalDisable.meta
+++ b/Assets/EditorCools/ConditionalDisable.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8baa1849e0cf141e8a08541ea209f78b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorCools/ConditionalDisable/DisabledAttribute.cs
+++ b/Assets/EditorCools/ConditionalDisable/DisabledAttribute.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class DisabledAttribute : PropertyAttribute
+{
+    public enum MethodLocation { PropertyClass, StaticClass }
+    public MethodLocation Location { get; private set; }
+    public string MethodName { get; private set; }
+    public Type MethodOwnerType { get; private set; }
+
+    public bool? DirectValue { get; private set; }
+
+    public DisabledAttribute(string methodName)
+    {
+        Location = MethodLocation.PropertyClass;
+        MethodName = methodName;
+    }
+
+    public DisabledAttribute(Type methodOwner, string methodName)
+    {
+        Location = MethodLocation.StaticClass;
+        MethodOwnerType = methodOwner;
+        MethodName = methodName;
+    }
+
+    public DisabledAttribute(bool directValue = true)
+    {
+        DirectValue = directValue;
+    }
+
+    public bool? GetDisabled(SerializedProperty property, Type objectType)
+    {
+        if (DirectValue != null)
+        {
+            return DirectValue;
+        }
+
+        var methodName = MethodName;
+
+        var methodOwnerType = Location == MethodLocation.PropertyClass ? objectType : MethodOwnerType;
+
+        var methodInfo = methodOwnerType.GetMethod
+            (methodName,
+            BindingFlags.NonPublic
+            | BindingFlags.Public
+            | BindingFlags.Static
+            | BindingFlags.Instance);
+
+        if (methodInfo == null)
+        {
+            Debug.LogError($"Method {methodName} In {methodOwnerType.FullName} Could Not Be Found!");
+            return null;
+        }
+
+        var methodInfoReturnValueIsStringArray = methodInfo.ReturnType == typeof(bool);
+        if (!methodInfoReturnValueIsStringArray)
+        {
+            Debug.LogError($"Method {methodName} In {methodOwnerType.FullName} Does Not Have A Return Type Of {typeof(bool).FullName}");
+            return null;
+        }
+
+        var invokeReference = Location == MethodLocation.StaticClass ? null : property.serializedObject.targetObject;
+
+        var returnValue = methodInfo.Invoke(invokeReference, null) as bool?;
+
+        return returnValue;
+    }
+}

--- a/Assets/EditorCools/ConditionalDisable/DisabledAttribute.cs.meta
+++ b/Assets/EditorCools/ConditionalDisable/DisabledAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0739241565bb44be5993989992e94f15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorCools/ConditionalDisable/Editor.meta
+++ b/Assets/EditorCools/ConditionalDisable/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 83362b242d3de42d8a06cd3e1226d9b1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorCools/ConditionalDisable/Editor/DisabledAttributePropertyDrawer.cs
+++ b/Assets/EditorCools/ConditionalDisable/Editor/DisabledAttributePropertyDrawer.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using UnityEditor;
+using UnityEngine;
+
+[CustomPropertyDrawer(typeof(DisabledAttribute))]
+public class DisabledAttributePropertyDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        var disabled = ((DisabledAttribute)attribute).GetDisabled(property, fieldInfo.DeclaringType);
+
+        if (disabled == null)
+        {
+            EditorGUI.LabelField(position, label);
+            return;
+        }
+
+        EditorGUI.BeginDisabledGroup((bool)disabled);
+        EditorGUI.PropertyField(position, property, label, true);
+        EditorGUI.EndDisabledGroup();
+    }
+}

--- a/Assets/EditorCools/ConditionalDisable/Editor/DisabledAttributePropertyDrawer.cs.meta
+++ b/Assets/EditorCools/ConditionalDisable/Editor/DisabledAttributePropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 96ea7a4c1549c446492e5658e4ad6490
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EditorCools/Samples/Test.cs
+++ b/Assets/EditorCools/Samples/Test.cs
@@ -83,4 +83,14 @@ public class Test : MonoBehaviour
 
     [EditorCools.Button(row: "row-2")]
     private void Row2Button3() => Debug.Log("Row 3 Button 3");
+
+    [Disabled]
+    public string alwaysDisabled = "This value can't be edited";
+
+    public bool disableFieldBelow;
+
+    [Disabled(nameof(GetToggleDisable))]
+    public string toggledDisable = "This value can be edited sometimes";
+
+    private bool GetToggleDisable() => disableFieldBelow;
 }


### PR DESCRIPTION
I have made an attribute that allows the user to disable certain fields based on some conditions.\
The disabled attribute accepts a direct value like `true`, which is the default when using it like this: `[Disabled]` or a name of a method similar to how the dropdown attribute works.

I have also added extra properties to the sample script:
```cs
[Disabled]
public string alwaysDisabled = "This value can't be edited";

public bool disableFieldBelow;

[Disabled(nameof(GetToggleDisable))]
public string toggledDisable = "This value can be edited sometimes";

private bool GetToggleDisable() => disableFieldBelow;
```